### PR TITLE
Update environment.yml to fix nni requirement

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,6 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - nni
   - numpy
   - hickle
   - pip
@@ -14,5 +13,6 @@ dependencies:
   - pip:
     - scikit-image
     - timm
+    - nni
     - tqdm
 prefix: /opt/anaconda3/envs/simvp


### PR DESCRIPTION
This YAML file throws a "ResolvePackageNotFound: nni" error when installing on a new Conda System (tested on Win10 and Ubuntu 22.04) with "conda env create -f environment.yml". Fixed by moving the nni package to the pip section.